### PR TITLE
Fix broken path 

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -106,7 +106,7 @@ module Slather
         raise StandardError, "No Coverage.profdata files found. Please make sure the \"Code Coverage\" checkbox is enabled in your scheme's Test action or the build_directory property is set."
       end
       xcode_path = `xcode-select -p`.strip
-      llvm_cov_command = xcode_path + "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile #{coverage_profdata} #{binary_file}"
+      llvm_cov_command = xcode_path + "/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile #{coverage_profdata} #{binary_file}"
       `#{llvm_cov_command}`
     end
     private :profdata_llvm_cov_output


### PR DESCRIPTION
`llvm_cov_command` could not be found because of the missing `\`
