### PR TITLE
support for schemes with spaces in them

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -110,7 +110,7 @@ module Slather
         raise StandardError, "No Coverage.profdata files found. Please make sure the \"Code Coverage\" checkbox is enabled in your scheme's Test action or the build_directory property is set."
       end
       xcode_path = `xcode-select -p`.strip
-      llvm_cov_command = File.join(xcode_path, "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile #{coverage_profdata} #{binary_file}")
+      llvm_cov_command = File.join(xcode_path, "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile '#{coverage_profdata}' '#{binary_file}'")
       `#{llvm_cov_command}`
     end
     private :profdata_llvm_cov_output


### PR DESCRIPTION
fix issue where spaces in the scheme name would result slather to fail with following error message:

error: Failed to load coverage: No such file or directory
