### PR TITLE
add missing slash to path for llvm-cov bin

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -106,7 +106,7 @@ module Slather
         raise StandardError, "No Coverage.profdata files found. Please make sure the \"Code Coverage\" checkbox is enabled in your scheme's Test action or the build_directory property is set."
       end
       xcode_path = `xcode-select -p`.strip
-      llvm_cov_command = xcode_path + "Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile #{coverage_profdata} #{binary_file}"
+      llvm_cov_command = xcode_path + "/Toolchains/XcodeDefault.xctoolchain/usr/bin/llvm-cov show -instr-profile #{coverage_profdata} #{binary_file}"
       `#{llvm_cov_command}`
     end
     private :profdata_llvm_cov_output


### PR DESCRIPTION
Fixing missing slash in path to llvm-cov binary, so that slather can successfully invoke llvm-cov.
In case it matters, these is the environment under which slather is executed:

> bash-3.2$ xcodebuild -version
> Xcode 7.1.1
> Build version 7B1005
> 
> bash-3.2$ ruby -v
> ruby 2.0.0p481 (2014-05-08 revision 45883) [universal.x86_64-darwin14]
