### PR TITLE
Re-encode llvm-cov output to prevent potential "invalid byte sequence" issue

### DIFF
--- a/lib/slather/project.rb
+++ b/lib/slather/project.rb
@@ -153,7 +153,7 @@ module Slather
       Dir["#{xctest_bundle_file}/**/#{xctest_bundle_file_name_noext}"].first
     end
 
-    def profdata_llvm_cov_output
+    def unsafe_profdata_llvm_cov_output
       profdata_coverage_dir = self.profdata_coverage_dir
       binary_file_arg = binary_file
 
@@ -168,8 +168,14 @@ module Slather
       puts "\nProcessing coverage file: #{profdata_file_arg}"
       puts "Against binary file: #{binary_file_arg}\n\n"
 
+
       llvm_cov_args = %W(show -instr-profile #{profdata_file_arg} #{binary_file_arg})
       `xcrun llvm-cov #{llvm_cov_args.shelljoin}`
+    end
+    private :unsafe_profdata_llvm_cov_output
+
+    def profdata_llvm_cov_output
+      unsafe_profdata_llvm_cov_output.encode!('UTF-8', 'binary', :invalid => :replace, undef: :replace)
     end
     private :profdata_llvm_cov_output
 

--- a/spec/slather/project_spec.rb
+++ b/spec/slather/project_spec.rb
@@ -124,6 +124,21 @@ describe Slather::Project do
     end
   end
 
+  describe "#invalid_characters" do
+    it "should correctly encode invalid characters" do
+      fixtures_project.stub(:input_format).and_return("profdata")
+      fixtures_project.stub(:ignore_list).and_return([])
+      Dir.stub(:[]).with("#{fixtures_project.build_directory}/**/Coverage.profdata").and_return(["/some/path/Coverage.profdata"])
+      fixtures_project.stub(:unsafe_profdata_llvm_cov_output).and_return("#{FIXTURES_SWIFT_FILE_PATH}:
+      1|    8|    func application(application: \255, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+      1|    9|        return true
+      0|   14|}")
+      fixtures_project.extend(Slather::CoverageService::HtmlOutput)
+      profdata_coverage_files = fixtures_project.send(:profdata_coverage_files)
+      expect(profdata_coverage_files.count).to eq(1)
+    end
+  end
+
   describe "#binary_file" do
 
     let(:build_directory) do


### PR DESCRIPTION
Re-encode llvm-cov output to prevent potential "invalid byte sequence" issue
